### PR TITLE
Dissipate toxomister cloud logic fixup

### DIFF
--- a/SonicMania/Objects/LRZ/Toxomister.c
+++ b/SonicMania/Objects/LRZ/Toxomister.c
@@ -110,6 +110,16 @@ void Toxomister_CheckPlayerCollisions(void)
     foreach_active(Player, player)
     {
         if (Player_CheckBadnikTouch(player, self, &Toxomister->hitboxBadnik)) {
+            if (self->parent) {
+                if (self->parent->grabbedPlayer) {
+                    self->parent->grabbedPlayer = NULL;
+                } else {
+                    self->parent->parent = NULL;
+                    RSDK.SetSpriteAnimation(Toxomister->aniFrames, 3, &self->parent->animator, true, 0);
+                    self->parent->state = Toxomister_StateCloud_Dissipate;
+                }
+            }
+
             if (Player_CheckBadnikBreak(player, self, true)) {
                 if (self->parent)
                     destroyEntity(self->parent);


### PR DESCRIPTION
Add missing logic after destroying the toxomister badnik whatever the player is grabbed or not.