### PR TITLE
Fix Ring_CheckObjectCollisions

### DIFF
--- a/SonicMania/Objects/Global/Ring.c
+++ b/SonicMania/Objects/Global/Ring.c
@@ -487,11 +487,22 @@ void Ring_CheckObjectCollisions(int32 x, int32 y)
     }
 
     if (xVel <= 0) {
-        if (!(collisionSides & 8) && RSDK.ObjectTileCollision(self, Zone->collisionLayers, CMODE_RWALL, self->collisionPlane, -x, 0, true))
+        if (!(collisionSides & 8)) {
+            if (RSDK.ObjectTileCollision(self, Zone->collisionLayers, CMODE_RWALL, self->collisionPlane, -x, 0, true))
+                self->velocity.x = -xVel;
+        }
+        else {
             self->velocity.x = -xVel;
+        }
     }
-    else if (!(collisionSides & 4) && RSDK.ObjectTileCollision(self, Zone->collisionLayers, CMODE_LWALL, self->collisionPlane, x, 0, true)) {
-        self->velocity.x = -xVel;
+    else {
+        if (!(collisionSides & 4)) {
+            if (RSDK.ObjectTileCollision(self, Zone->collisionLayers, CMODE_LWALL, self->collisionPlane, x, 0, true))
+                self->velocity.x = -xVel;
+        }
+        else {
+            self->velocity.x = -xVel;
+        }
     }
 
     if (yVel <= 0) {


### PR DESCRIPTION
Fixes a bug in Ring_CheckObjectCollisions that prevented lost rings from interacting with collisionSides

Current behavior - notice how the rings stop moving on the decomp
https://github.com/user-attachments/assets/976d31fb-4055-495f-a8b7-f9e968ac6da5

Fixed behavior -
https://github.com/user-attachments/assets/dd14bb92-fead-4076-9bc8-e191fb04e175

Tested on both v5 & v5U