### PR TITLE
Fix incorrect self->underwater check in Player_State_KnuxWallClimb

### DIFF
--- a/SonicMania/Objects/Global/Player.c
+++ b/SonicMania/Objects/Global/Player.c
@@ -5083,7 +5083,7 @@ void Player_State_KnuxWallClimb(void)
             }
 
             self->velocity.y = -0x38000;
-            if (self->underwater) {
+            if (self->underwater == true) {
                 self->velocity.x >>= 1;
                 self->velocity.y >>= 1;
                 self->groundVel >>= 1;


### PR DESCRIPTION
Fixes an issue on Player_State_KnuxWallClimb that prevented the player from correctly launching from a jump underwater

Water_State_Water will set player->underwater to an entity slot. For KnuxWallClimb, the state incorrectly checks for `if (self->underwater != 0)` instead of `if (self->underwater == 1)`

Current behavior:
https://github.com/user-attachments/assets/9a474787-2214-41c8-ae62-6126d2282ae8

Fixed behavior:
https://github.com/user-attachments/assets/4642d5ae-8237-42aa-8915-5d3842fc5fd9

Fixes #313 