### PR TITLE
Fixed BSS medal achievements

### DIFF
--- a/SonicMania/Objects/BSS/BSS_Setup.c
+++ b/SonicMania/Objects/BSS/BSS_Setup.c
@@ -697,6 +697,9 @@ void BSS_Setup_HandleSteppedObjects(void)
                     if (pos >= 0) {
                         ProgressRAM *progress = GameProgress_GetProgressRAM();
                         if (progress) {
+                            int32 goldMedalCount   = progress->goldMedalCount;
+                            int32 silverMedalCount = progress->silverMedalCount;
+
                             uint8 medal = BSS_Setup->playField[fieldPos] == BSS_MEDAL_SILVER ? 1
                                           : BSS_Setup->playField[fieldPos] == BSS_MEDAL_GOLD ? 2
                                                                                              : 0;
@@ -704,11 +707,11 @@ void BSS_Setup_HandleSteppedObjects(void)
                             if (medal)
                                 GameProgress_GiveMedal(pos, medal);
 
-                            if (progress->allGoldMedals && progress->goldMedalCount == 31) {
+                            if (progress->allGoldMedals && goldMedalCount == GAMEPROGRESS_MEDAL_COUNT - 1) {
                                 API_UnlockAchievement(&achievementList[ACH_GOLD_MEDAL]);
                             }
 
-                            if (progress->allSilverMedals && progress->silverMedalCount == 31) {
+                            if (progress->allSilverMedals && silverMedalCount == GAMEPROGRESS_MEDAL_COUNT - 1) {
                                 API_UnlockAchievement(&achievementList[ACH_SILVER_MEDAL]);
                             }
                         }


### PR DESCRIPTION
The decompilation checks against the medalCount variables which were just incremented by GiveMedal instead of checking against the previous values

<img width="890" height="544" alt="image" src="https://github.com/user-attachments/assets/405b67da-9b03-42d7-bfe7-c2aa66f7c967" />

<img width="474" height="325" alt="image" src="https://github.com/user-attachments/assets/087c2d05-789f-4e64-a0b5-11acbe69ac73" />